### PR TITLE
Add chunk extraction pipeline and docs updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
 # n8n / credenciales / env
 .env
 *.env
+.env.*
+.env.local
+.env.*.local
+.envrc
+.envrc.*
+env_file
+env_files/
+.env.vault
+*.env.backup
 **/credentials*.json
 **/secrets*
 **/config*
@@ -8,5 +17,20 @@
 # node
 node_modules/
 
-# artefactos locales
+# python / scripts
+__pycache__/
+*.py[cod]
+
+# datos de ejecución locales
+data/
+tmp/
+logs/
 *.log
+*.sqlite
+*.db
+*.bak
+*.tmp
+
+# sistema operativo
+.DS_Store
+Thumbs.db

--- a/docs/IMPORTAR_WORKFLOWS.md
+++ b/docs/IMPORTAR_WORKFLOWS.md
@@ -1,0 +1,43 @@
+# Importar workflows de DrAI en n8n
+
+Este repositorio contiene los flujos exportados de n8n que soportan DrAI. Sigue estos pasos para cargarlos en una instancia nueva y dejar las credenciales listas.
+
+## 1. Preparar variables de entorno
+
+1. Copia el archivo `.env.example` y ajusta las claves necesarias:
+   ```bash
+   cp .env.example .env
+   ```
+2. Completa los valores que usará n8n (por ejemplo `OPENAI_API_KEY`).
+3. Si ejecutas n8n en Docker, referencia el archivo mediante [`env_file`](https://docs.docker.com/compose/environment-variables/set-environment-variables/#use-the-env_file-attribute):
+   ```yaml
+   services:
+     n8n:
+       image: n8nio/n8n
+       env_file:
+         - ./n8n/.env
+   ```
+4. Para despliegues sin Docker puedes cargar las variables con `source .env` antes de iniciar el proceso o configurarlas en el gestor de servicios correspondiente.
+
+## 2. Importar los workflows
+
+1. Ingresa al panel de n8n con una cuenta con permisos de edición.
+2. En la barra lateral elige **Workflows → Import**.
+3. Selecciona el archivo JSON desde la carpeta `workflows/` de este repo y confirma la importación.
+4. Repite el proceso para cada flujo que necesites (`DrAI`, `KB Ingest Sources`, `KB Pruebas RAG`, etc.).
+
+## 3. Revisar credenciales
+
+Después de importar:
+
+- Abre **Credentials** y vincula las conexiones que requieren claves (por ejemplo PostgreSQL, Telegram o credenciales HTTP).
+- Confirma que las variables utilizadas en cabeceras (`Bearer {{$env.OPENAI_API_KEY}}`) estén presentes en el entorno.
+
+## 4. Dependencias recomendadas
+
+El flujo `KB Ingest Sources` espera que en el host estén instalados:
+
+- [`pdftotext`](https://poppler.freedesktop.org/) (`poppler-utils`) para extraer texto paginado.
+- Una herramienta de OCR (por ejemplo `ocrmypdf`) para manejar PDFs escaneados. Los nodos marcarán `chunk_warning` cuando detecten que falta texto.
+
+Mantén estos paquetes disponibles en la imagen/host donde corre n8n para evitar fallas en el proceso de chunking.

--- a/workflows/DrAI (16).json
+++ b/workflows/DrAI (16).json
@@ -154,7 +154,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{$env.OPENAI_API_KEY}}"
+              "value": "={{ 'Bearer ' + $env.OPENAI_API_KEY }}"
             },
             {
               "name": "Content-Type",

--- a/workflows/KB Ingest Sources (1).json
+++ b/workflows/KB Ingest Sources (1).json
@@ -97,7 +97,7 @@
     },
     {
       "parameters": {
-        "command": "=mv \"{{$json.src_path.trim()}}\" \"{{$json.dest_path.trim()}}\"\n"
+        "command": "={{ (() => {\n  const src = String($json.src_path || $json.path || $json.filePath || $json.file || '').trim();\n  const dest = String($json.clean_dest_path || $json.dest_path || '').trim();\n  if (!src || !dest) {\n    throw new Error('Missing source/dest path for move');\n  }\n  const parts = dest.split('/');\n  if (parts.length > 1) {\n    parts.pop();\n  }\n  const destDir = parts.join('/') || '/data/kb/processed';\n  return `mkdir -p \"${destDir}\" && mv \"${src}\" \"${dest}\"`;\n})() }}"
       },
       "type": "n8n-nodes-base.executeCommand",
       "typeVersion": 1,
@@ -183,7 +183,7 @@
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
       "position": [
-        1648,
+        2528,
         192
       ],
       "id": "9f19d4fe-0fd8-40cb-8749-67fcbb646a62",
@@ -266,7 +266,7 @@
             {
               "id": "5d71566e-ef5c-4da5-96b8-8a4ea92a867e",
               "name": "clean_dest_path",
-              "value": "={{\n  (() => {\n    const dp = String($json.dest_path || '').trim();\n    if (dp && !dp.endsWith('/')) return dp; // ya viene bien\n    const base =\n      String(($json.dest_name || '').trim()) ||\n      (\n        String(($json.filename || $json.fileName || 'file').trim())\n          .normalize('NFD').replace(/[\\u0300-\\u036f]/g,'')\n          .replace(/\\.pdf$/i,'').replace(/\\s+/g,'_').replace(/[^A-Za-z0-9_.-]/g,'')\n        + '_' + $now.toFormat('yyyyLLdd_HHmmss') + '.pdf'\n      );\n    return '/data/kb/processed/' + base;\n  })()\n}}\n",
+              "value": "={{\n  (() => {\n    const rawDest = String($json.dest_path || '').trim();\n    if (rawDest) {\n      return rawDest;\n    }\n    const baseName = String(($json.dest_name || '').trim());\n    if (baseName) {\n      return '/data/kb/processed/' + baseName;\n    }\n    const fallback = String(($json.filename || $json.fileName || 'file').trim())\n      .normalize('NFD').replace(/[\\u0300-\\u036f]/g,'')\n      .replace(/\\.pdf$/i,'')\n      .replace(/\\s+/g,'_')\n      .replace(/[^A-Za-z0-9_.-]/g,'');\n    const stamped = fallback + '_' + $now.toFormat('yyyyLLdd_HHmmss') + '.pdf';\n    return '/data/kb/processed/' + stamped;\n  })()\n}}",
               "type": "string"
             }
           ]
@@ -321,11 +321,159 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
       "position": [
-        1440,
+        2320,
         192
       ],
       "id": "efe0b563-f1b8-4be5-a6fa-846d136985d0",
       "name": "IF guardarraíl (antes del Update)"
+    },
+    {
+      "parameters": {
+        "command": "=python3 - <<'PY'\nimport json\nimport re\nimport subprocess\nimport sys\n\npdf_path = {{ JSON.stringify((String($json.clean_dest_path || $json.dest_path || '').trim())) }}\nif not pdf_path:\n    print(json.dumps({'error': 'missing_pdf_path', 'chunks': []}))\n    sys.exit(0)\ncmd = ['pdftotext', '-layout', '-enc', 'UTF-8', pdf_path, '-']\ntry:\n    proc = subprocess.run(cmd, capture_output=True, text=True, check=True)\nexcept FileNotFoundError:\n    print(json.dumps({'error': 'pdftotext_not_found', 'chunks': []}))\n    sys.exit(0)\nexcept subprocess.CalledProcessError as exc:\n    print(json.dumps({\n        'error': 'pdftotext_failed',\n        'stderr': (exc.stderr or '').strip(),\n        'returncode': exc.returncode,\n        'chunks': []\n    }))\n    sys.exit(0)\ntext = proc.stdout or ''\ntext_stripped = text.strip()\npages_raw = [page for page in text.split('\\f') if page.strip()]\nchunks = []\nchunk_index = 0\nmax_chunk = 1200\nmin_chunk = 180\nfor page_number, raw_page in enumerate(pages_raw, start=1):\n    page_text = raw_page.strip()\n    if not page_text:\n        continue\n    paragraphs = [p.strip() for p in re.split(r'\\n\\s*\\n+', page_text) if p.strip()]\n    buffer = ''\n    for para in paragraphs:\n        segments = [para[i:i + max_chunk] for i in range(0, len(para), max_chunk)] or ['']\n        for segment in segments:\n            piece = segment.strip()\n            if not piece:\n                continue\n            candidate = f\"{buffer}\\n\\n{piece}\".strip() if buffer else piece\n            if len(candidate) <= max_chunk:\n                buffer = candidate\n            else:\n                if buffer:\n                    chunk_index += 1\n                    chunks.append({'chunk_index': chunk_index, 'page_number': page_number, 'content': buffer})\n                buffer = piece\n    if buffer:\n        if len(buffer) < min_chunk and chunks:\n            chunks[-1]['content'] = f\"{chunks[-1]['content']}\\n\\n{buffer}\".strip()\n        else:\n            chunk_index += 1\n            chunks.append({'chunk_index': chunk_index, 'page_number': page_number, 'content': buffer})\nresult = {\n    'chunks': chunks,\n    'page_count': len(pages_raw),\n    'text_length': len(text_stripped),\n    'ocr_suspect': len(text_stripped) < 80\n}\nprint(json.dumps(result, ensure_ascii=False))\nPY"
+      },
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [
+        1440,
+        192
+      ],
+      "id": "efc18fed-261e-44da-b48c-ccec0a0197bf",
+      "name": "Extract PDF text & chunk"
+    },
+    {
+      "parameters": {
+        "functionCode": "const item = items[0] || { json: {} };\nconst raw = item.json.stdout || '';\nlet parsed = {};\nif (raw) {\n  try {\n    parsed = JSON.parse(raw);\n  } catch (error) {\n    throw new Error('Chunk command did not return JSON: ' + raw.slice(0, 400));\n  }\n}\nconst chunks = Array.isArray(parsed.chunks) ? parsed.chunks : [];\nitem.json.chunkData = parsed;\nitem.json.chunkCount = chunks.length;\nitem.json.chunkError = parsed.error || null;\nitem.json.needsOcr = Boolean(parsed.ocr_suspect) || chunks.length === 0 || Boolean(item.json.chunkError);\nitem.json.hasChunks = !item.json.needsOcr && chunks.length > 0;\nitem.json.chunkStdErr = parsed.stderr || null;\nitem.json.chunkTextLength = parsed.text_length ?? null;\nreturn items;"
+      },
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        1616,
+        192
+      ],
+      "id": "852a4fad-c51b-4890-8e56-38d08b6aa4bb",
+      "name": "Parse chunk output"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "conditions": [
+            {
+              "id": "d2ba6767-a98f-42b2-8a9b-01d61cf482ee",
+              "leftValue": "={{$json.hasChunks}}",
+              "rightValue": "",
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and",
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 2
+          }
+        },
+        "looseTypeValidation": true,
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        1792,
+        192
+      ],
+      "id": "e22bf642-c090-4082-b67c-4e6e43b947cd",
+      "name": "Chunks disponibles?"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "fd062400-ac13-442d-b8f1-1f97ed355161",
+              "name": "chunks_json",
+              "value": "={{ JSON.stringify($json.chunkData?.chunks || []).replace(/'/g, \"''\") }}",
+              "type": "string"
+            },
+            {
+              "id": "4ec1e9d6-3eff-4a75-a086-d15e5ef73e00",
+              "name": "chunk_count",
+              "value": "={{ $json.chunkCount || 0 }}",
+              "type": "number"
+            },
+            {
+              "id": "9a53f25d-3dbd-4a94-b24f-87b70d30d524",
+              "name": "chunk_text_length",
+              "value": "={{ $json.chunkTextLength || 0 }}",
+              "type": "number"
+            },
+            {
+              "id": "68d4d0c8-fdc2-4261-bd4f-a036de00840c",
+              "name": "page_count",
+              "value": "={{ $json.chunkData?.page_count || 0 }}",
+              "type": "number"
+            }
+          ]
+        },
+        "includeOtherFields": true,
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        1968,
+        96
+      ],
+      "id": "0d3b82af-d868-468f-b326-49e1be0d35e0",
+      "name": "Preparar payload de chunks"
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "DELETE FROM kb_chunks\n WHERE source_id = {{$json.clean_source_id}};\n\nWITH incoming AS (\n  SELECT\n    (chunk->>'chunk_index')::int AS chunk_index,\n    (chunk->>'page_number')::int AS page_number,\n    trim(chunk->>'content') AS content\n  FROM jsonb_array_elements('{{$json.chunks_json}}'::jsonb) AS chunk\n),\ninserted AS (\n  INSERT INTO kb_chunks (source_id, chunk_index, page_number, content)\n  SELECT\n    {{$json.clean_source_id}} AS source_id,\n    chunk_index,\n    page_number,\n    content\n  FROM incoming\n  ORDER BY chunk_index\n  RETURNING 1\n)\nSELECT\n  {{$json.clean_source_id}}::int       AS clean_source_id,\n  '{{ String($json.clean_dest_path || '').replace(/'/g, \"''\") }}'::text AS clean_dest_path,\n  {{$json.chunk_count || 0}}::int      AS chunk_count,\n  {{$json.chunk_text_length || 0}}::int AS chunk_text_length,\n  {{$json.page_count || 0}}::int       AS page_count;\n",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        2144,
+        96
+      ],
+      "id": "8f56cb2d-fd7e-47b8-b607-524eb38c283c",
+      "name": "Refrescar kb_chunks",
+      "credentials": {
+        "postgres": {
+          "id": "j4uy2P7wwsJyISqB",
+          "name": "Postgres DrAI"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "f52dde17-fafe-4b04-a398-9d2d8a147dca",
+              "name": "chunk_warning",
+              "value": "={{ $json.chunkError ? ('Extracción fallida: ' + $json.chunkError) : 'Se detectó PDF sin texto utilizable (revisar OCR)' }}",
+              "type": "string"
+            }
+          ]
+        },
+        "includeOtherFields": true,
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        1968,
+        304
+      ],
+      "id": "904de846-5fb0-45b8-a869-aad9ddb4bed7",
+      "name": "Marcar necesidad de OCR"
     }
   ],
   "pinData": {},
@@ -451,7 +599,7 @@
       "main": [
         [
           {
-            "node": "IF guardarraíl (antes del Update)",
+            "node": "Extract PDF text & chunk",
             "type": "main",
             "index": 0
           }
@@ -470,6 +618,79 @@
         [
           {
             "node": "Update Source Path",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract PDF text & chunk": {
+      "main": [
+        [
+          {
+            "node": "Parse chunk output",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse chunk output": {
+      "main": [
+        [
+          {
+            "node": "Chunks disponibles?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Chunks disponibles?": {
+      "main": [
+        [
+          {
+            "node": "Preparar payload de chunks",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Marcar necesidad de OCR",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Preparar payload de chunks": {
+      "main": [
+        [
+          {
+            "node": "Refrescar kb_chunks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Refrescar kb_chunks": {
+      "main": [
+        [
+          {
+            "node": "IF guardarraíl (antes del Update)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Marcar necesidad de OCR": {
+      "main": [
+        [
+          {
+            "node": "IF guardarraíl (antes del Update)",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary
- harden the KB ingestion workflow by sanitising file moves, extracting PDF text with `pdftotext`, inserting chunks into `kb_chunks`, and flagging OCR issues when no text is found
- update the DrAI embedding request to read the OpenAI API key from the environment and extend the gitignore rules
- document how to import the workflows into n8n and configure the environment via `env_file`

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c8d931f1008324be878f3eba06fbba