### PR TITLE
Actualizar workflow KB Ingest Sources 6.0

### DIFF
--- a/workflows/KB Ingest Sources 6.0.json
+++ b/workflows/KB Ingest Sources 6.0.json
@@ -16,7 +16,7 @@
     },
     {
       "parameters": {
-        "functionCode": "// Lee el puntero que dejó el extractor\nconst out = JSON.parse($json.stdout || '{}');\nif (!out.file) throw new Error('Extractor no devolvió ruta (out.file)');\nreturn [{ json: { file: out.file, source_id: out.source_id } }];\n"
+        "functionCode": "// Lee el puntero que dej\u00f3 el extractor\nconst out = JSON.parse($json.stdout || '{}');\nif (!out.file) throw new Error('Extractor no devolvi\u00f3 ruta (out.file)');\nreturn [{ json: { file: out.file, source_id: out.source_id } }];\n"
       },
       "id": "dbd4c255-ebb7-484d-8488-418f264d49aa",
       "name": "Prepare Chunk Payload",
@@ -139,7 +139,7 @@
     },
     {
       "parameters": {
-        "functionCode": "// Repack (per-item) — lee embedding desde donde realmente llega la respuesta del HTTP\n\nconst meta = $json || {};\nconst content = typeof meta.content === \"string\" ? meta.content : \"\";\n\n// Detectar el embedding en cualquiera de estos sitios\nlet emb = null;\nif (Array.isArray(meta?.data) && Array.isArray(meta.data[0]?.embedding)) {\n  emb = meta.data[0].embedding;                 // HTTP → Response Format = JSON (en raíz)\n} else if (meta?.body && Array.isArray(meta.body?.data) && Array.isArray(meta.body.data[0]?.embedding)) {\n  emb = meta.body.data[0].embedding;            // algunas configs lo ponen en body\n} else if (meta?.openai_response && Array.isArray(meta.openai_response?.data)\n           && Array.isArray(meta.openai_response.data[0]?.embedding)) {\n  emb = meta.openai_response.data[0].embedding; // por si usas un wrapper\n} else if (Array.isArray(meta?.embedding)) {\n  emb = meta.embedding;                          // proxies\n}\n\nreturn [{\n  json: {\n    source_id:   meta.source_id   ?? null,\n    source_name: meta.source_name ?? null,\n    file_name:   meta.file_name   ?? null,\n    file_path:   meta.file_path   ?? null,\n    source_path: meta.source_path ?? null,\n    dest_path:   meta.dest_path   ?? null,\n    page_count:  meta.page_count  ?? null,\n    text_length: typeof content === \"string\" ? content.length : (meta.text_length ?? 0),\n\n    chunks_json: [{\n      chunk_index: meta.chunk_index ?? meta.chunkIndex ?? 1,\n      page_number: meta.page_number ?? meta.pageNumber ?? 1,\n      content,\n      status: Array.isArray(emb) ? \"ok\" : \"no_embedding\",\n      embedding: Array.isArray(emb) ? emb : null,\n    }],\n  }\n}];\n"
+        "functionCode": "// Repack (per-item) \u2014 lee embedding desde donde realmente llega la respuesta del HTTP\n\nconst meta = $json || {};\nconst content = typeof meta.content === \"string\" ? meta.content : \"\";\n\n// Detectar el embedding en cualquiera de estos sitios\nlet emb = null;\nif (Array.isArray(meta?.data) && Array.isArray(meta.data[0]?.embedding)) {\n  emb = meta.data[0].embedding;                 // HTTP \u2192 Response Format = JSON (en ra\u00edz)\n} else if (meta?.body && Array.isArray(meta.body?.data) && Array.isArray(meta.body.data[0]?.embedding)) {\n  emb = meta.body.data[0].embedding;            // algunas configs lo ponen en body\n} else if (meta?.openai_response && Array.isArray(meta.openai_response?.data)\n           && Array.isArray(meta.openai_response.data[0]?.embedding)) {\n  emb = meta.openai_response.data[0].embedding; // por si usas un wrapper\n} else if (Array.isArray(meta?.embedding)) {\n  emb = meta.embedding;                          // proxies\n}\n\nreturn [{\n  json: {\n    source_id:   meta.source_id   ?? null,\n    source_name: meta.source_name ?? null,\n    file_name:   meta.file_name   ?? null,\n    file_path:   meta.file_path   ?? null,\n    source_path: meta.source_path ?? null,\n    dest_path:   meta.dest_path   ?? null,\n    page_count:  meta.page_count  ?? null,\n    text_length: typeof content === \"string\" ? content.length : (meta.text_length ?? 0),\n\n    chunks_json: [{\n      chunk_index: meta.chunk_index ?? meta.chunkIndex ?? 1,\n      page_number: meta.page_number ?? meta.pageNumber ?? 1,\n      content,\n      status: Array.isArray(emb) ? \"ok\" : \"no_embedding\",\n      embedding: Array.isArray(emb) ? emb : null,\n    }],\n  }\n}];\n"
       },
       "id": "5611a0c9-61de-487b-8bc4-0fe2b5f49c39",
       "name": "Repack Chunks",
@@ -191,8 +191,21 @@
               "responseFormat": "json"
             }
           },
-          "timeout": 60000
-        }
+          "timeout": 60000,
+          "retry": {
+            "maxAttempts": 3,
+            "wait": {
+              "type": "exponential",
+              "interval": 1000,
+              "factor": 2,
+              "maxInterval": 4000
+            }
+          }
+        },
+        "retryOnFail": true,
+        "maxTries": 3,
+        "waitBetweenTries": 1000,
+        "onError": "continueRegularOutput"
       },
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
@@ -203,9 +216,10 @@
       "id": "bf932f62-3e2b-4dc9-b3da-43ddbd45f847",
       "name": "HTTP Request (embeddings)",
       "retryOnFail": true,
-      "maxTries": 5,
-      "waitBetweenTries": 2000,
-      "onError": "continueRegularOutput"
+      "maxTries": 3,
+      "waitBetweenTries": 1000,
+      "onError": "continueRegularOutput",
+      "continueOnFail": true
     },
     {
       "parameters": {
@@ -240,7 +254,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Fan-Out for Embeddings — 1 item = 1 chunk (liviano, sin duplicar listas grandes)\nconst itemsIn = $input.all().map(it => it.json?.data ?? it.json);\nif (!itemsIn.length) return [];\n\nlet meta = {};\nlet chunks = [];\n\n// Caso: un solo item trae .chunks[]\nif (Array.isArray(itemsIn[0]?.chunks) && itemsIn[0].chunks.length) {\n  const f = itemsIn[0];\n  meta = {\n    source_id:   f.source_id   ?? f.sourceId   ?? null,\n    source_name: f.source_name ?? f.sourceName ?? null,\n    file_name:   f.file_name   ?? f.fileName   ?? null,\n    file_path:   f.file_path   ?? f.filePath   ?? null,\n    source_path: f.source_path ?? f.sourcePath ?? (f.file_path ?? null),\n    dest_path:   f.dest_path   ?? f.destPath   ?? null,\n    page_count:  f.page_count  ?? f.pageCount  ?? null,\n  };\n  chunks = f.chunks.map((c, i) => ({\n    chunk_index: c.chunk_index ?? c.chunkIndex ?? (i + 1),\n    page_number: c.page_number ?? c.pageNumber ?? 1,\n    content:     c.content ?? '',\n  }));\n} else {\n  // Caso: ya viene 1 item por chunk desde Extract\n  const f = itemsIn[0] ?? {};\n  meta = {\n    source_id:   f.source_id   ?? f.sourceId   ?? null,\n    source_name: f.source_name ?? f.sourceName ?? null,\n    file_name:   f.file_name   ?? f.fileName   ?? null,\n    file_path:   f.file_path   ?? f.filePath   ?? null,\n    source_path: f.source_path ?? f.sourcePath ?? (f.file_path ?? null),\n    dest_path:   f.dest_path   ?? f.destPath   ?? null,\n    page_count:  f.page_count  ?? f.pageCount  ?? null,\n  };\n  chunks = itemsIn.map((j, i) => ({\n    chunk_index: j.chunk_index ?? j.chunkIndex ?? (i + 1),\n    page_number: j.page_number ?? j.pageNumber ?? 1,\n    content:     j.content ?? '',\n  }));\n}\n\nreturn chunks.map(c => ({\n  json: { ...meta, ...c, text_length: (c.content?.length ?? 0) }\n}));\n"
+        "jsCode": "// Fan-Out for Embeddings \u2014 1 item = 1 chunk (liviano, sin duplicar listas grandes)\nconst itemsIn = $input.all().map(it => it.json?.data ?? it.json);\nif (!itemsIn.length) return [];\n\nlet meta = {};\nlet chunks = [];\n\n// Caso: un solo item trae .chunks[]\nif (Array.isArray(itemsIn[0]?.chunks) && itemsIn[0].chunks.length) {\n  const f = itemsIn[0];\n  meta = {\n    source_id:   f.source_id   ?? f.sourceId   ?? null,\n    source_name: f.source_name ?? f.sourceName ?? null,\n    file_name:   f.file_name   ?? f.fileName   ?? null,\n    file_path:   f.file_path   ?? f.filePath   ?? null,\n    source_path: f.source_path ?? f.sourcePath ?? (f.file_path ?? null),\n    dest_path:   f.dest_path   ?? f.destPath   ?? null,\n    page_count:  f.page_count  ?? f.pageCount  ?? null,\n  };\n  chunks = f.chunks.map((c, i) => ({\n    chunk_index: c.chunk_index ?? c.chunkIndex ?? (i + 1),\n    page_number: c.page_number ?? c.pageNumber ?? 1,\n    content:     c.content ?? '',\n  }));\n} else {\n  // Caso: ya viene 1 item por chunk desde Extract\n  const f = itemsIn[0] ?? {};\n  meta = {\n    source_id:   f.source_id   ?? f.sourceId   ?? null,\n    source_name: f.source_name ?? f.sourceName ?? null,\n    file_name:   f.file_name   ?? f.fileName   ?? null,\n    file_path:   f.file_path   ?? f.filePath   ?? null,\n    source_path: f.source_path ?? f.sourcePath ?? (f.file_path ?? null),\n    dest_path:   f.dest_path   ?? f.destPath   ?? null,\n    page_count:  f.page_count  ?? f.pageCount  ?? null,\n  };\n  chunks = itemsIn.map((j, i) => ({\n    chunk_index: j.chunk_index ?? j.chunkIndex ?? (i + 1),\n    page_number: j.page_number ?? j.pageNumber ?? 1,\n    content:     j.content ?? '',\n  }));\n}\n\nreturn chunks.map(c => ({\n  json: { ...meta, ...c, text_length: (c.content?.length ?? 0) }\n}));\n"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -266,7 +280,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Get first item from Fan-Out for Embeddings for paths\nconst it = $items(\"Fan-Out for Embeddings\", 0, 0)[0];\nreturn [{ json: it.json }];\n"
+        "jsCode": "const refItems = $items('Fan-Out for Embeddings', 0, 0) || [];\nif (Array.isArray(refItems) && refItems.length && refItems[0]?.json) {\n  return [{ json: refItems[0].json }];\n}\nreturn [{ json: $json }];\n"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -321,7 +335,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Meta del mismo índice desde el nodo de texto\nconst meta = $items('Clone Meta', 0, $itemIndex)[0].json;\n// Embedding del HTTP actual\nconst emb = $json?.data?.[0]?.embedding ?? null;\n\nreturn [{\n  json: {\n    source_id:   meta.source_id,\n    chunk_index: meta.chunk_index,\n    page_number: meta.page_number ?? 1,\n    content:     meta.content ?? '',\n    embedding:   emb\n  }\n}];\n"
+        "jsCode": "const metaItem = $items('Clone Meta', 0, $itemIndex)?.[0]?.json ?? {};\nconst merged = $json ?? {};\nconst embItem = $items('Embedding Response Handler', 0, $itemIndex)?.[0]?.json ?? {};\nconst embeddingHttp = Array.isArray(embItem.embedding) ? embItem.embedding : null;\nconst embeddingMeta = Array.isArray(metaItem.embedding) ? metaItem.embedding : null;\nconst embedding = Array.isArray(embeddingHttp) ? embeddingHttp : (Array.isArray(embeddingMeta) ? embeddingMeta : null);\nconst status = embItem.status ?? (Array.isArray(embedding) ? 'ok' : 'failed');\nconst content = metaItem.content ?? merged.content ?? merged.chunk_text ?? metaItem.chunk_text ?? '';\nreturn [{\n  json: {\n    ...metaItem,\n    content,\n    embedding,\n    embedding_status: status,\n    chunk_text: merged.chunk_text ?? content,\n    meta: metaItem\n  }\n}];\n"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -331,6 +345,177 @@
       ],
       "id": "746237c4-c829-4fab-91ee-c7212fb94a49",
       "name": "Build Row"
+    },
+    {
+      "parameters": {
+        "jsCode": "const src = $json || {};\nlet embedding = null;\nlet status = 'failed';\nconst pick = obj => Array.isArray(obj?.data) && Array.isArray(obj.data[0]?.embedding) ? obj.data[0].embedding : null;\nconst sources = [src, src.body, src.openai_response];\nfor (const candidate of sources) {\n  const emb = pick(candidate);\n  if (Array.isArray(emb)) {\n    embedding = emb;\n    status = 'ok';\n    break;\n  }\n}\nif (!Array.isArray(embedding) && Array.isArray(src?.embedding)) {\n  embedding = src.embedding;\n  status = 'ok';\n}\nreturn [{ json: { embedding: Array.isArray(embedding) ? embedding : null, status: Array.isArray(embedding) ? 'ok' : status } }];\n"
+      },
+      "id": "d82a9f47-53ad-4c6a-adac-e67d345fb7c1",
+      "name": "Embedding Response Handler",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1040,
+        560
+      ]
+    },
+    {
+      "parameters": {
+        "keepOnlySet": true,
+        "values": {
+          "number": [
+            {
+              "name": "source_id",
+              "value": "={{$json.source_id || $json.meta.source_id}}"
+            },
+            {
+              "name": "chunk_index",
+              "value": "={{$json.chunk_index || $json.meta.chunk_index}}"
+            },
+            {
+              "name": "page_number",
+              "value": "={{$json.page_number || $json.meta.page_number || 1}}"
+            }
+          ],
+          "string": [
+            {
+              "name": "content",
+              "value": "={{$json.content || $json.chunk_text || $json.meta.content || $json.meta.chunk_text || ''}}"
+            }
+          ],
+          "json": [
+            {
+              "name": "embedding",
+              "value": "={{$json.embedding}}"
+            }
+          ],
+          "boolean": [],
+          "collection": [],
+          "fixedCollection": [],
+          "dateTime": []
+        }
+      },
+      "id": "edcd242f-dffd-4b80-9bcb-7078e7432090",
+      "name": "Rearmar Payload",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        1504,
+        560
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "if ($json.chunk_index == null || $json.chunk_index <= 0) {\n  throw new Error('chunk_index inv\u00e1lido antes del INSERT');\n}\nreturn $json;\n"
+      },
+      "id": "a9011556-ed49-4da7-9c85-4f43d5e8709e",
+      "name": "Function Guard",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        1664,
+        560
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "ALTER TABLE kb_chunks DROP CONSTRAINT IF EXISTS kb_chunks_pkey;\nALTER TABLE kb_chunks ADD CONSTRAINT kb_chunks_pkey PRIMARY KEY (source_id, chunk_index);",
+        "options": {}
+      },
+      "id": "e0305182-2027-4ae7-829c-d7c64c6b42b7",
+      "name": "Ensure KB PK",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        -1568,
+        96
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "j4uy2P7wwsJyISqB",
+          "name": "Postgres DrAI"
+        }
+      }
+    },
+    {
+      "parameters": {},
+      "id": "3aa3603d-0272-4583-9207-eb17089ddf90",
+      "name": "Manual Trigger (Tests)",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -1760,
+        96
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT COALESCE(MAX(source_id), 1) AS source_id FROM kb_sources;",
+        "options": {}
+      },
+      "id": "6e53d942-3e71-404f-8db3-8e141aa93043",
+      "name": "Fetch Test Source",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        -1376,
+        96
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "j4uy2P7wwsJyISqB",
+          "name": "Postgres DrAI"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "functionCode": "const sourceId = $json.source_id ?? 1;\nconst baseChunk = 10;\nconst items = [];\nfor (let i = 0; i < 3; i++) {\n  const idx = baseChunk + i;\n  const page = i + 1;\n  items.push({\n    json: {\n      source_id: sourceId,\n      chunk_index: idx,\n      page_number: page,\n      content: `Test chunk ${idx}`,\n      chunk_text: `Test chunk ${idx}`,\n      dest_path: null,\n      embedding: [0.01 * (i + 1), 0.02 * (i + 1), 0.03 * (i + 1)]\n    }\n  });\n}\nreturn items;\n"
+      },
+      "id": "f589ce37-b2c0-4f68-b4f3-489b2410737b",
+      "name": "Test Runner",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        -1184,
+        96
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const inputs = $input.all();\nconst result = [];\nfor (const batch of inputs) {\n  for (const item of batch) {\n    result.push(item);\n  }\n}\nreturn result;\n"
+      },
+      "id": "f9573d31-a947-4f52-bf19-834e57d08e8f",
+      "name": "Collect Items for Loop",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        464,
+        416
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "-- 1) Conteo y rango\nWITH s AS (SELECT MAX(source_id) id FROM kb_sources)\nSELECT COUNT(*) total, MIN(chunk_index) min_idx, MAX(chunk_index) max_idx\nFROM kb_chunks WHERE source_id = (SELECT id FROM s);\n\n-- 2) Duplicados\nWITH s AS (SELECT MAX(source_id) id FROM kb_sources)\nSELECT chunk_index, COUNT(*) c\nFROM kb_chunks\nWHERE source_id = (SELECT id FROM s)\nGROUP BY chunk_index\nHAVING COUNT(*) > 1\nORDER BY chunk_index;\n\n-- 3) Embeddings nulos\nWITH s AS (SELECT MAX(source_id) id FROM kb_sources)\nSELECT SUM((embedding IS NULL)::int) AS null_embeddings\nFROM kb_chunks WHERE source_id = (SELECT id FROM s);",
+        "options": {}
+      },
+      "id": "fce5c085-a0a5-4264-ae5b-8295e798fee7",
+      "name": "Checks",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        1824,
+        656
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "j4uy2P7wwsJyISqB",
+          "name": "Postgres DrAI"
+        }
+      }
     }
   ],
   "pinData": {},
@@ -454,7 +639,7 @@
       "main": [
         [
           {
-            "node": "Loop Over Items",
+            "node": "Collect Items for Loop",
             "type": "main",
             "index": 0
           }
@@ -489,6 +674,11 @@
         [
           {
             "node": "Loop Over Items",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Checks",
             "type": "main",
             "index": 0
           }
@@ -532,7 +722,7 @@
       "main": [
         [
           {
-            "node": "Merge Meta+Emb",
+            "node": "Embedding Response Handler",
             "type": "main",
             "index": 0
           }
@@ -540,6 +730,99 @@
       ]
     },
     "Build Row": {
+      "main": [
+        [
+          {
+            "node": "Rearmar Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Collect Items for Loop": {
+      "main": [
+        [
+          {
+            "node": "Loop Over Items",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger (Tests)": {
+      "main": [
+        [
+          {
+            "node": "Ensure KB PK",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch Test Source",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Ensure KB PK": {
+      "main": [
+        [
+          {
+            "node": "Fetch Test Source",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Test Source": {
+      "main": [
+        [
+          {
+            "node": "Test Runner",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Test Runner": {
+      "main": [
+        [
+          {
+            "node": "Collect Items for Loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Embedding Response Handler": {
+      "main": [
+        [
+          {
+            "node": "Merge Meta+Emb",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Rearmar Payload": {
+      "main": [
+        [
+          {
+            "node": "Function Guard",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function Guard": {
       "main": [
         [
           {


### PR DESCRIPTION
## Summary
- endurecer el nodo HTTP de embeddings con reintentos exponenciales y manejo de errores sin contaminar la rama de metadatos
- introducir el preprocesado de respuestas y el set "Rearmar Payload" más guardia para asegurar chunk_index válido antes del INSERT
- añadir nodos de soporte (Ensure KB PK, Test Runner, Checks) para preparar la clave primaria, generar lotes de prueba y auditar inserciones en kb_chunks

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd44f742988324888ad1e9b1c61301