### PR TITLE
Fix KB ingest chunk handling in workflow

### DIFF
--- a/workflows/KB Ingest Sources 7.0.json
+++ b/workflows/KB Ingest Sources 7.0.json
@@ -16,7 +16,7 @@
     },
     {
       "parameters": {
-        "functionCode": "// Lee el puntero que dejó el extractor\nconst out = JSON.parse($json.stdout || '{}');\nif (!out.file) throw new Error('Extractor no devolvió ruta (out.file)');\nreturn [{ json: { file: out.file, source_id: out.source_id } }];\n"
+        "functionCode": "// Lee el puntero que dej\u00f3 el extractor\nconst out = JSON.parse($json.stdout || '{}');\nif (!out.file) throw new Error('Extractor no devolvi\u00f3 ruta (out.file)');\nreturn [{ json: { file: out.file, source_id: out.source_id } }];\n"
       },
       "id": "dbd4c255-ebb7-484d-8488-418f264d49aa",
       "name": "Prepare Chunk Payload",
@@ -139,7 +139,7 @@
     },
     {
       "parameters": {
-        "functionCode": "// Repack (per-item) — lee embedding desde donde realmente llega la respuesta del HTTP\n\nconst meta = $json || {};\nconst content = typeof meta.content === \"string\" ? meta.content : \"\";\n\n// Detectar el embedding en cualquiera de estos sitios\nlet emb = null;\nif (Array.isArray(meta?.data) && Array.isArray(meta.data[0]?.embedding)) {\n  emb = meta.data[0].embedding;                 // HTTP → Response Format = JSON (en raíz)\n} else if (meta?.body && Array.isArray(meta.body?.data) && Array.isArray(meta.body.data[0]?.embedding)) {\n  emb = meta.body.data[0].embedding;            // algunas configs lo ponen en body\n} else if (meta?.openai_response && Array.isArray(meta.openai_response?.data)\n           && Array.isArray(meta.openai_response.data[0]?.embedding)) {\n  emb = meta.openai_response.data[0].embedding; // por si usas un wrapper\n} else if (Array.isArray(meta?.embedding)) {\n  emb = meta.embedding;                          // proxies\n}\n\nreturn [{\n  json: {\n    source_id:   meta.source_id   ?? null,\n    source_name: meta.source_name ?? null,\n    file_name:   meta.file_name   ?? null,\n    file_path:   meta.file_path   ?? null,\n    source_path: meta.source_path ?? null,\n    dest_path:   meta.dest_path   ?? null,\n    page_count:  meta.page_count  ?? null,\n    text_length: typeof content === \"string\" ? content.length : (meta.text_length ?? 0),\n\n    chunks_json: [{\n      chunk_index: meta.chunk_index ?? meta.chunkIndex ?? 1,\n      page_number: meta.page_number ?? meta.pageNumber ?? 1,\n      content,\n      status: Array.isArray(emb) ? \"ok\" : \"no_embedding\",\n      embedding: Array.isArray(emb) ? emb : null,\n    }],\n  }\n}];\n"
+        "functionCode": "// Repack (per-item) \u2014 lee embedding desde donde realmente llega la respuesta del HTTP\n\nconst meta = $json || {};\nconst content = typeof meta.content === \"string\" ? meta.content : \"\";\n\n// Detectar el embedding en cualquiera de estos sitios\nlet emb = null;\nif (Array.isArray(meta?.data) && Array.isArray(meta.data[0]?.embedding)) {\n  emb = meta.data[0].embedding;                 // HTTP \u2192 Response Format = JSON (en ra\u00edz)\n} else if (meta?.body && Array.isArray(meta.body?.data) && Array.isArray(meta.body.data[0]?.embedding)) {\n  emb = meta.body.data[0].embedding;            // algunas configs lo ponen en body\n} else if (meta?.openai_response && Array.isArray(meta.openai_response?.data)\n           && Array.isArray(meta.openai_response.data[0]?.embedding)) {\n  emb = meta.openai_response.data[0].embedding; // por si usas un wrapper\n} else if (Array.isArray(meta?.embedding)) {\n  emb = meta.embedding;                          // proxies\n}\n\nreturn [{\n  json: {\n    source_id:   meta.source_id   ?? null,\n    source_name: meta.source_name ?? null,\n    file_name:   meta.file_name   ?? null,\n    file_path:   meta.file_path   ?? null,\n    source_path: meta.source_path ?? null,\n    dest_path:   meta.dest_path   ?? null,\n    page_count:  meta.page_count  ?? null,\n    text_length: typeof content === \"string\" ? content.length : (meta.text_length ?? 0),\n\n    chunks_json: [{\n      chunk_index: meta.chunk_index ?? meta.chunkIndex ?? 1,\n      page_number: meta.page_number ?? meta.pageNumber ?? 1,\n      content,\n      status: Array.isArray(emb) ? \"ok\" : \"no_embedding\",\n      embedding: Array.isArray(emb) ? emb : null,\n    }],\n  }\n}];\n"
       },
       "id": "5611a0c9-61de-487b-8bc4-0fe2b5f49c39",
       "name": "Repack Chunks",
@@ -203,9 +203,10 @@
       "id": "bf932f62-3e2b-4dc9-b3da-43ddbd45f847",
       "name": "HTTP Request (embeddings)",
       "retryOnFail": true,
-      "maxTries": 5,
-      "waitBetweenTries": 2000,
-      "onError": "continueRegularOutput"
+      "maxTries": 3,
+      "waitBetweenTries": "={{ Math.pow(2, (($retryAttempt ?? 1) - 1)) * 1000 }}",
+      "onError": "continueRegularOutput",
+      "continueOnFail": true
     },
     {
       "parameters": {
@@ -240,7 +241,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Fan-Out for Embeddings — 1 item = 1 chunk (liviano, sin duplicar listas grandes)\nconst itemsIn = $input.all().map(it => it.json?.data ?? it.json);\nif (!itemsIn.length) return [];\n\nlet meta = {};\nlet chunks = [];\n\n// Caso: un solo item trae .chunks[]\nif (Array.isArray(itemsIn[0]?.chunks) && itemsIn[0].chunks.length) {\n  const f = itemsIn[0];\n  meta = {\n    source_id:   f.source_id   ?? f.sourceId   ?? null,\n    source_name: f.source_name ?? f.sourceName ?? null,\n    file_name:   f.file_name   ?? f.fileName   ?? null,\n    file_path:   f.file_path   ?? f.filePath   ?? null,\n    source_path: f.source_path ?? f.sourcePath ?? (f.file_path ?? null),\n    dest_path:   f.dest_path   ?? f.destPath   ?? null,\n    page_count:  f.page_count  ?? f.pageCount  ?? null,\n  };\n  chunks = f.chunks.map((c, i) => ({\n    chunk_index: c.chunk_index ?? c.chunkIndex ?? (i + 1),\n    page_number: c.page_number ?? c.pageNumber ?? 1,\n    content:     c.content ?? '',\n  }));\n} else {\n  // Caso: ya viene 1 item por chunk desde Extract\n  const f = itemsIn[0] ?? {};\n  meta = {\n    source_id:   f.source_id   ?? f.sourceId   ?? null,\n    source_name: f.source_name ?? f.sourceName ?? null,\n    file_name:   f.file_name   ?? f.fileName   ?? null,\n    file_path:   f.file_path   ?? f.filePath   ?? null,\n    source_path: f.source_path ?? f.sourcePath ?? (f.file_path ?? null),\n    dest_path:   f.dest_path   ?? f.destPath   ?? null,\n    page_count:  f.page_count  ?? f.pageCount  ?? null,\n  };\n  chunks = itemsIn.map((j, i) => ({\n    chunk_index: j.chunk_index ?? j.chunkIndex ?? (i + 1),\n    page_number: j.page_number ?? j.pageNumber ?? 1,\n    content:     j.content ?? '',\n  }));\n}\n\nreturn chunks.map(c => ({\n  json: { ...meta, ...c, text_length: (c.content?.length ?? 0) }\n}));\n"
+        "jsCode": "// Fan-Out for Embeddings \u2014 1 item = 1 chunk (liviano, sin duplicar listas grandes)\nconst itemsIn = $input.all().map(it => it.json?.data ?? it.json);\nif (!itemsIn.length) return [];\n\nlet meta = {};\nlet chunks = [];\n\n// Caso: un solo item trae .chunks[]\nif (Array.isArray(itemsIn[0]?.chunks) && itemsIn[0].chunks.length) {\n  const f = itemsIn[0];\n  meta = {\n    source_id:   f.source_id   ?? f.sourceId   ?? null,\n    source_name: f.source_name ?? f.sourceName ?? null,\n    file_name:   f.file_name   ?? f.fileName   ?? null,\n    file_path:   f.file_path   ?? f.filePath   ?? null,\n    source_path: f.source_path ?? f.sourcePath ?? (f.file_path ?? null),\n    dest_path:   f.dest_path   ?? f.destPath   ?? null,\n    page_count:  f.page_count  ?? f.pageCount  ?? null,\n  };\n  chunks = f.chunks.map((c, i) => ({\n    chunk_index: c.chunk_index ?? c.chunkIndex ?? (i + 1),\n    page_number: c.page_number ?? c.pageNumber ?? 1,\n    content:     c.content ?? '',\n  }));\n} else {\n  // Caso: ya viene 1 item por chunk desde Extract\n  const f = itemsIn[0] ?? {};\n  meta = {\n    source_id:   f.source_id   ?? f.sourceId   ?? null,\n    source_name: f.source_name ?? f.sourceName ?? null,\n    file_name:   f.file_name   ?? f.fileName   ?? null,\n    file_path:   f.file_path   ?? f.filePath   ?? null,\n    source_path: f.source_path ?? f.sourcePath ?? (f.file_path ?? null),\n    dest_path:   f.dest_path   ?? f.destPath   ?? null,\n    page_count:  f.page_count  ?? f.pageCount  ?? null,\n  };\n  chunks = itemsIn.map((j, i) => ({\n    chunk_index: j.chunk_index ?? j.chunkIndex ?? (i + 1),\n    page_number: j.page_number ?? j.pageNumber ?? 1,\n    content:     j.content ?? '',\n  }));\n}\n\nreturn chunks.map(c => ({\n  json: { ...meta, ...c, text_length: (c.content?.length ?? 0) }\n}));\n"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -279,7 +280,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Clone Meta: deja pasar tal cual el item con chunk_index/page_number/content y metadatos\nreturn [{ json: $json }];\n"
+        "jsCode": "const meta = $json ? JSON.parse(JSON.stringify($json)) : {}\nreturn [{\n  json: Object.assign({}, meta, { meta }),\n  pairedItem: { item: 0 }\n}]\n"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -321,7 +322,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Meta del mismo índice desde el nodo de texto\nconst meta = $items('Clone Meta', 0, $itemIndex)[0].json;\n// Embedding del HTTP actual\nconst emb = $json?.data?.[0]?.embedding ?? null;\n\nreturn [{\n  json: {\n    source_id:   meta.source_id,\n    chunk_index: meta.chunk_index,\n    page_number: meta.page_number ?? 1,\n    content:     meta.content ?? '',\n    embedding:   emb\n  }\n}];\n"
+        "jsCode": "const merged = $json || {}\nconst meta = merged.meta ? { ...merged.meta } : {}\nconst httpEmbedding = Array.isArray(merged.embedding) ? merged.embedding : null\nconst fallbackEmbedding = Array.isArray(meta.embedding) ? meta.embedding : null\nconst embedding = httpEmbedding || fallbackEmbedding || null\nconst status = merged.status || (httpEmbedding ? 'ok' : (fallbackEmbedding ? 'fallback' : 'no_embedding'))\nconst chunkIndex = merged.chunk_index != null ? merged.chunk_index : (meta.chunk_index != null ? meta.chunk_index : null)\nconst pageNumber = merged.page_number != null ? merged.page_number : (meta.page_number != null ? meta.page_number : 1)\nconst content = merged.content || merged.chunk_text || meta.content || meta.chunk_text || ''\nreturn [{\n  json: {\n    ...meta,\n    ...merged,\n    meta,\n    chunk_index: chunkIndex,\n    page_number: pageNumber,\n    content,\n    embedding,\n    status,\n  }\n}]\n"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -331,6 +332,159 @@
       ],
       "id": "746237c4-c829-4fab-91ee-c7212fb94a49",
       "name": "Build Row"
+    },
+    {
+      "parameters": {
+        "functionCode": "const src = $json || {}\nlet embedding = null\nconst data = Array.isArray(src.data) ? src.data : (src.body && Array.isArray(src.body.data) ? src.body.data : [])\nif (Array.isArray(src.embedding)) {\n  embedding = src.embedding\n} else if (Array.isArray(data) && Array.isArray(data[0] && data[0].embedding)) {\n  embedding = data[0].embedding\n}\nconst status = embedding ? 'ok' : (src.status || 'failed')\nreturn [{\n  json: embedding ? { embedding } : { embedding: null, status },\n  pairedItem: { item: 0 }\n}]\n"
+      },
+      "id": "b1deaaa2-6fbb-434a-8efe-5bdaea066b22",
+      "name": "Embedding Output Guard",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        1120,
+        560
+      ]
+    },
+    {
+      "parameters": {
+        "keepOnlySet": true,
+        "values": {
+          "string": [
+            {
+              "name": "source_id",
+              "value": "={{$json.source_id || $json.meta.source_id}}"
+            },
+            {
+              "name": "chunk_index",
+              "value": "={{$json.chunk_index || $json.meta.chunk_index}}"
+            },
+            {
+              "name": "page_number",
+              "value": "={{$json.page_number || $json.meta.page_number || 1}}"
+            },
+            {
+              "name": "content",
+              "value": "={{$json.content || $json.chunk_text || $json.meta.content || $json.meta.chunk_text || ''}}"
+            }
+          ],
+          "json": [
+            {
+              "name": "embedding",
+              "value": "={{$json.embedding}}"
+            }
+          ]
+        }
+      },
+      "id": "31f27c9f-d89b-42f7-a334-65954fee6581",
+      "name": "Rearmar Payload",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        1520,
+        560
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "if ($json.chunk_index == null || $json.chunk_index <= 0) {\n  throw new Error('chunk_index inv\u00e1lido antes del INSERT')\n}\nreturn $json\n"
+      },
+      "id": "08f755ff-816c-49c4-af4a-10dd88c7317f",
+      "name": "Function Guard",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        1680,
+        560
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "-- 1) Conteo y rango\nWITH s AS (SELECT MAX(source_id) id FROM kb_sources)\nSELECT COUNT(*) total, MIN(chunk_index) min_idx, MAX(chunk_index) max_idx\nFROM kb_chunks WHERE source_id = (SELECT id FROM s);\n\n-- 2) Duplicados\nWITH s AS (SELECT MAX(source_id) id FROM kb_sources)\nSELECT chunk_index, COUNT(*) c\nFROM kb_chunks\nWHERE source_id = (SELECT id FROM s)\nGROUP BY chunk_index\nHAVING COUNT(*) > 1\nORDER BY chunk_index;\n\n-- 3) Embeddings nulos\nWITH s AS (SELECT MAX(source_id) id FROM kb_sources)\nSELECT SUM((embedding IS NULL)::int) AS null_embeddings\nFROM kb_chunks WHERE source_id = (SELECT id FROM s);\n",
+        "options": {}
+      },
+      "id": "91230bb2-116c-4820-92f5-138c6529b310",
+      "name": "Checks",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        1840,
+        720
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "j4uy2P7wwsJyISqB",
+          "name": "Postgres DrAI"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "ALTER TABLE kb_chunks DROP CONSTRAINT IF EXISTS kb_chunks_pkey;\nALTER TABLE kb_chunks ADD CONSTRAINT kb_chunks_pkey PRIMARY KEY (source_id, chunk_index);\n",
+        "options": {}
+      },
+      "id": "be27a47c-9b41-4a83-bb23-874f36a22743",
+      "name": "Ensure KB PK",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        560,
+        592
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "j4uy2P7wwsJyISqB",
+          "name": "Postgres DrAI"
+        }
+      },
+      "executeOnce": true
+    },
+    {
+      "parameters": {},
+      "id": "d37095b9-bd5f-4bce-8171-7692105a7a04",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -1568,
+        144
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "WITH existing AS (\n  SELECT source_id\n  FROM kb_sources\n  WHERE source_name = 'Test Runner Source'\n  ORDER BY source_id DESC\n  LIMIT 1\n),\nins AS (\n  INSERT INTO kb_sources (source_name, source_path)\n  SELECT 'Test Runner Source', '/data/test-runner'\n  WHERE NOT EXISTS (SELECT 1 FROM existing)\n  RETURNING source_id\n)\nSELECT source_id FROM ins\nUNION ALL\nSELECT source_id FROM existing\nLIMIT 1;\n",
+        "options": {}
+      },
+      "id": "a80f0352-e490-4c65-8ef2-8eca20e66a2f",
+      "name": "Test Runner Source",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        -1360,
+        144
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "j4uy2P7wwsJyISqB",
+          "name": "Postgres DrAI"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "functionCode": "const sourceId = $json.source_id || $json.sourceId\nif (sourceId == null) {\n  throw new Error('Test Runner: source_id no disponible')\n}\nconst baseChunk = 10\nconst embeddings = [0.11, 0.22, 0.33, 0.44]\nconst items = []\nfor (let i = 0; i < 3; i++) {\n  const chunkIndex = baseChunk + i\n  const pageNumber = i + 1\n  const content = 'Test chunk ' + chunkIndex\n  items.push({\n    json: {\n      meta: {\n        source_id: sourceId,\n        chunk_index: chunkIndex,\n        page_number: pageNumber,\n        content,\n        chunk_text: content,\n        embedding: embeddings\n      },\n      source_id: sourceId,\n      chunk_index: chunkIndex,\n      page_number: pageNumber,\n      content,\n      chunk_text: content,\n      test_run: true,\n      embedding: embeddings\n    }\n  })\n}\nreturn items\n"
+      },
+      "id": "cd0c6a27-92e0-4e0b-a2b0-34a4559a3de7",
+      "name": "Test Runner Items",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        -1152,
+        144
+      ]
     }
   ],
   "pinData": {},
@@ -457,6 +611,11 @@
             "node": "Loop Over Items",
             "type": "main",
             "index": 0
+          },
+          {
+            "node": "Ensure KB PK",
+            "type": "main",
+            "index": 0
           }
         ]
       ]
@@ -489,6 +648,11 @@
         [
           {
             "node": "Loop Over Items",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Checks",
             "type": "main",
             "index": 0
           }
@@ -532,7 +696,7 @@
       "main": [
         [
           {
-            "node": "Merge Meta+Emb",
+            "node": "Embedding Output Guard",
             "type": "main",
             "index": 0
           }
@@ -543,7 +707,73 @@
       "main": [
         [
           {
+            "node": "Rearmar Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Embedding Output Guard": {
+      "main": [
+        [
+          {
+            "node": "Merge Meta+Emb",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Rearmar Payload": {
+      "main": [
+        [
+          {
+            "node": "Function Guard",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function Guard": {
+      "main": [
+        [
+          {
             "node": "Insert KB Chunks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Test Runner Source",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Test Runner Source": {
+      "main": [
+        [
+          {
+            "node": "Test Runner Items",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Test Runner Items": {
+      "main": [
+        [
+          {
+            "node": "Loop Over Items",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary
- adjust the embeddings HTTP request to continue on failure, retry with exponential backoff, and emit only embedding payloads via a sanitizer function
- enforce by-position merge pairing, rebuild the payload through a dedicated set node with guard, and keep the Postgres insert query plus new validation checks
- add a manual test runner that seeds three chunks, ensure the kb_chunks primary key, and run verification SQL after inserts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd6eac611c8324ad18406afbfbfe3b